### PR TITLE
Remove unused import

### DIFF
--- a/grub
+++ b/grub
@@ -13,7 +13,6 @@ import re
 import subprocess
 import shutil
 import datetime
-import q
 
 DOCUMENTATION = """
 ---


### PR DESCRIPTION
`q` is not used right now and is usually not installed by default.